### PR TITLE
Australia and New Zealand Switching to AS923-1

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,3 @@ h3idx files are created which contain a binary list of user h3 hexes for each re
 The dataset was originally download from https://osm-boundaries.com/ based off the regions.csv file using getgeojson.py(this code is no longer used but moved to archive). Each LoRaWAN region is captured in its own file by country.
 
 regions.geojson contains all regions. It is created by running plans.py which takes each region file and runs unary_union function to merge all neighbouring polygons with the same region and combines them all into a single file. 
-
-
-


### PR DESCRIPTION
On December 10th, 2021, during the third meeting of DeWi’s LoRaWAN Working Group, members voted to initiate a change of frequency plan for Australia and New Zealand from AU915 to AS923-1. The vote count was 3 for and 2 abstentions. The [video](https://vimeo.com/675944391) and [minutes](https://docs.google.com/document/d/1d9W4z9Krs88zsnUkXF3OnexJ3zE4Ei9Gv2ERFfaf0B0/) of the meeting are available.

On February 8th, [HIP45](https://github.com/helium/HIP/blob/main/0045-lorawan-frequency-plan-selection.md) was formally approved and this PR formally initiates the change under that framework. This PR begins the minimum of 4 weeks period for written discussion. After this period, if formal dissent to the change is lodged, a virtual town hall will be held. If there is no resolution, an on-chain vote will be held where one hotspot in the affected region is given one vote.

**Discussed reasons for switching to AS923-1**
* Four large public operators (NNNCo, Spark, Ventia) use AS923-1. The only large operator to use AU915 is TTN.
* Roaming with other countries in the region is easier as most use AS923-1 (eg: logistics tracking).
**Regions on Helium Network with AU915**
![image](https://user-images.githubusercontent.com/1606640/156107732-5c9dc058-880b-40f6-aa54-5f0f38558918.png)
**Regions on Helium Network with AS923-1**
![image](https://user-images.githubusercontent.com/1606640/156107696-0bf23c3e-df8b-434b-b554-2f1c7db71255.png)
* Large organizations are requesting AS923-1 compatibility (Sydney Water, Urban Utilities)
* Downlink coverage on AS923-1 has 6dB high coverage thanks to using 125 KHz instead of 500 KHz (assuming the same spreading factor). That being said, gateways tend to have higher output compared to devices which allow for symmetrical link margin.
* AS923-1 is a dynamic channel plan which provides flexibility to easily expand/move uplink and downlink channels as the capacity increases or to deal with potential interference
* The Join Procedure is faster on 8-channel networks as unlike AU915, the AS923-1 Join channels are fixed. AU915 has a ⅛ chance of Joining on every attempt as it tries every band.

**Discussed reasons for _not_ switching to AS923-1**
* The AU915 band used by the Helium Network (ch8-17, 916.8 MHz-918.2 MHz) is not typically used by AS923-1 devics and therefore does not share capacity with these devices. However, AS923-1 networks may very well set the dynamic channels to these frequencies. Moreover, TTN does use these same AU915 channels.
* Switching Helium to sub-band 5 (indexing at 0) would provide the possibility of a LoRaWAN device stack that could join on either frequency plan easily, thus making it possible for a primarily AS923-1 device to Join on AU915

